### PR TITLE
Mapping will prioritize failed tests

### DIFF
--- a/compliance-ui/components/Grid.js
+++ b/compliance-ui/components/Grid.js
@@ -111,27 +111,65 @@ export const Grid = ({ releases: { releases }, link = false, tab }) => {
     <div>
       {releases.map(item => {
         return (
-          <ul key={item.release} name="grid" className={grid} tabIndex="0">
-            {item.controls.map((controls, index) => {
-              const controlID = controls.control;
-              const check =
-                controls.verifications[0].passed === "true" ? greenBG : redBG;
+          <React.Fragment key={item.release}>
+            <ul name="grid" className={grid} tabIndex="0">
+              {item.controls.map(controls => {
+                const controlID = controls.control;
+                var stop = false;
+                return (
+                  <React.Fragment>
+                    {controls.verifications.map((verifications, index) => {
+                      const check =
+                        verifications.passed === "true" ? greenBG : redBG;
+                      if (verifications.passed === "false" && stop === false) {
+                        stop = true;
 
-              return (
-                <ControlBox
-                  key={index}
-                  status={controls.verifications[0].passed}
-                  tab={tab}
-                  id={controlID}
-                  style={check}
-                  description={controls.verifications[0].description}
-                  title={controls.control}
-                  timestamp={controls.verifications[0].timestamp}
-                  link={link}
-                />
-              );
-            })}
-          </ul>
+                        return (
+                          <ControlBox
+                            key={index}
+                            status={verifications.passed}
+                            tab={tab}
+                            id={controlID}
+                            references={verifications.references}
+                            component={verifications.component}
+                            style={check}
+                            description={verifications.description}
+                            title={controls.control}
+                            timestamp={verifications.timestamp}
+                            link={link}
+                          />
+                        );
+                      }
+                    })}
+
+                    {controls.verifications.map((verifications, index) => {
+                      const check =
+                        verifications.passed === "true" ? greenBG : redBG;
+                      if (verifications.passed === "true" && stop === false) {
+                        stop = true;
+
+                        return (
+                          <ControlBox
+                            key={index}
+                            status={verifications.passed}
+                            tab={tab}
+                            id={controlID}
+                            references={verifications.references}
+                            component={verifications.component}
+                            style={check}
+                            description={verifications.description}
+                            title={controls.control}
+                            timestamp={verifications.timestamp}
+                            link={link}
+                          />
+                        );
+                      }
+                    })}
+                  </React.Fragment>
+                );
+              })}
+            </ul>
+          </React.Fragment>
         );
       })}
     </div>

--- a/compliance-ui/components/Grid.js
+++ b/compliance-ui/components/Grid.js
@@ -117,7 +117,7 @@ export const Grid = ({ releases: { releases }, link = false, tab }) => {
                 const controlID = controls.control;
                 var stop = false;
                 return (
-                  <React.Fragment>
+                  <React.Fragment key={controlID}>
                     {controls.verifications.map((verifications, index) => {
                       const check =
                         verifications.passed === "true" ? greenBG : redBG;


### PR DESCRIPTION
## This PR consists of:
- Creating a variable `stop` which initializes as false
- Passed and Failed verifications are now rendered in two separate mapping statements
  - These will only loop if `stop === false`
  - Once a control is successfully rendered -> `stop === true` (guarantees only rendering one box of each control)
  - The mapping statement for the Failed controls will precede the Passed statement (this will guarantee that only one box is rendered, a Failed takes priority over Passed if it exists and then exits the loop)

** **Will hopefully be merging Grid and Grid2 (from `Grid.js`)  into one item in my next PR** **