### PR TITLE
Failed badge

### DIFF
--- a/compliance-ui/components/ReleaseBox.js
+++ b/compliance-ui/components/ReleaseBox.js
@@ -150,7 +150,7 @@ const ReleaseBox = ({ release, timestamp, passed, passing, total, link }) => {
               <div className={releaseTitle}>
                 <h3 name="releasebox-title">
                   <span>
-                    {passed === "true" ? "Passed" : "Failed"} Release: #
+                    {passed === "true" ? "Passed" : "Failed"} release: #
                     {release}
                   </span>
                 </h3>{" "}

--- a/compliance-ui/components/ReleaseBox.js
+++ b/compliance-ui/components/ReleaseBox.js
@@ -98,6 +98,11 @@ const releaseTitle = css`
     margin: 0 0 ${theme.spacing.sm} 0;
   }
 
+  h3[name="releasebox-title"] span {
+    font-size: ${theme.font.lg};
+    color: ${theme.colour.redDark};
+  }
+
   ${mediaQuery.md(css`
     width: 100%;
   `)};
@@ -143,7 +148,12 @@ const ReleaseBox = ({ release, timestamp, passed, passing, total, link }) => {
           >
             <div name="inner-container">
               <div className={releaseTitle}>
-                <h3 name="releasebox-title">Release: #{release}</h3>{" "}
+                <h3 name="releasebox-title">
+                  <span>
+                    {passed === "true" ? "Passed" : "Failed"} Release: #
+                    {release}
+                  </span>
+                </h3>{" "}
                 <p name="releasebox-timestamp">{timestamp}</p>
               </div>
               <div className={releaseBadges}>
@@ -152,12 +162,6 @@ const ReleaseBox = ({ release, timestamp, passed, passing, total, link }) => {
                   className={passed === "true" ? passingText : failingText}
                 >
                   {passing} / {total} checks
-                </span>
-                <span
-                  name="releasebox-passed"
-                  className={passed === "true" ? passingText : failingText}
-                >
-                  {passed === "true" ? "Passed" : "Failed"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## This PR consists of the following:

### Updating the failed identifier
- Tim made a good point that the way the badges were set up previous to this PR was a little confusing
- Due to the fact that they are side by side, it makes it seem like it reads `22/28 failing` although they should be separate values, i.e: `22/28` , `failing`... where: `failing` <- represents status of release `22/28` <- represents number of tests passing out of total
- Made status value part of `releaseTitle` (`inline` and set to `redDark`)

| Before | After |
|--------|-------|
|    ![screen shot 2019-01-07 at 14 01 04](https://user-images.githubusercontent.com/30609058/50787549-b5683800-1284-11e9-96e9-850a0487850e.png)    |   ![screen shot 2019-01-07 at 14 00 03](https://user-images.githubusercontent.com/30609058/50787550-b5683800-1284-11e9-9804-03ef6b57af55.png)    |