### PR TITLE
A11y first pass

### DIFF
--- a/compliance-ui/components/ActionBar.js
+++ b/compliance-ui/components/ActionBar.js
@@ -8,11 +8,14 @@ const actions = css`
   align-items: center;
   justify-content: space-between;
   background: ${theme.colour.blackLight};
-  padding: ${theme.spacing.sm} ${theme.spacing.xxl};
+  padding: ${theme.spacing.sm} 0 2rem ${theme.spacing.xxl};
 
   ${mediaQuery.lg(css`
-    padding: ${theme.spacing.xs} ${theme.spacing.xl} ${theme.spacing.xs}
-      ${theme.spacing.xl};
+    padding: ${theme.spacing.sm} 0 2rem ${theme.spacing.xl};
+  `)};
+
+  ${mediaQuery.md(css`
+    padding: ${theme.spacing.sm} 0 2rem ${theme.spacing.xl};
   `)};
 
   ${mediaQuery.sm(css`
@@ -21,6 +24,8 @@ const actions = css`
       font-size: ${theme.font.sm};
     }
 
+    padding: ${theme.spacing.sm} 0 2rem ${theme.spacing.xl};
+
     img {
       display: none;
     }
@@ -28,11 +33,6 @@ const actions = css`
     svg {
       height: 0.4rem;
     }
-
-    ${mediaQuery.lg(css`
-      padding: ${theme.spacing.xs} ${theme.spacing.xl} ${theme.spacing.md}
-        ${theme.spacing.xl};
-    `)};
   `)};
 `;
 

--- a/compliance-ui/components/BackToTopButton.js
+++ b/compliance-ui/components/BackToTopButton.js
@@ -6,7 +6,7 @@ const topPage = css`
   display: flex;
   align-items: center;
   color: ${theme.colour.black};
-  margin: ${theme.spacing.md} 0 ${theme.spacing.xl} ${theme.spacing.xxl};
+  margin: ${theme.spacing.lg} 0 ${theme.spacing.xxl} ${theme.spacing.xxl};
   text-decoration: underline;
   cursor: pointer;
 
@@ -36,7 +36,12 @@ const topPage = css`
 
 export const BackToTopButton = ({ click }) => {
   return (
-    <div className={topPage} onClick={click}>
+    <div
+      tabIndex="0"
+      className={topPage}
+      onClick={click}
+      aria-label="click this link to navigate to the top of the page"
+    >
       <UpArrowCircle />
       <span>Back To Top of Page</span>
     </div>

--- a/compliance-ui/components/Collapsible.js
+++ b/compliance-ui/components/Collapsible.js
@@ -98,12 +98,13 @@ export class Collapsible extends React.Component {
           <div className={toggleContainer}>
             <h2 name="collapsible-h1">{title}</h2>
             <div className={this.state.open ? collapseIn : collapse}>
-              <MainDescription
-                key="collapsible"
-                description={
-                  description.length === 0 ? newDescription : description
-                }
-              />
+              {description.length === 0 ? (
+                <MainDescription
+                  key="collapsible"
+                  description={newDescription}
+                />
+              ) : null}
+
               {description.map(description => {
                 return (
                   <MainDescription

--- a/compliance-ui/components/Collapsible.js
+++ b/compliance-ui/components/Collapsible.js
@@ -38,7 +38,7 @@ const container = css`
   background: ${theme.colour.white};
   padding: ${theme.spacing.lg};
   line-height: 1.6rem;
-  h1[name="collapsible-h1"] {
+  h2[name="collapsible-h1"] {
     margin-top: 0;
     color: ${theme.colour.blackLight};
     margin-bottom: ${theme.spacing.md};
@@ -82,18 +82,28 @@ export class Collapsible extends React.Component {
 
   render() {
     const { title, description, control } = this.props;
+    var newDescription;
+
+    if (description.length === 0) {
+      newDescription =
+        "The description seems to be missing. Sorry for the inconvenience, please try back at a later time if you are still looking for more information on the control in question.";
+    }
     return (
       <div>
-        <div className={container}>
+        <div
+          tabIndex="0"
+          aria-label={`Control ${title} ${newDescription}:  `}
+          className={container}
+        >
           <div className={toggleContainer}>
-            <h1 name="collapsible-h1">{title}</h1>
+            <h2 name="collapsible-h1">{title}</h2>
             <div className={this.state.open ? collapseIn : collapse}>
-              {description.length === 0 ? (
-                <MainDescription
-                  key="collapsible"
-                  description="The description seems to be missing. Sorry for the inconvenience, please try back at a later time if you are still looking for more information on the control in question."
-                />
-              ) : null}
+              <MainDescription
+                key="collapsible"
+                description={
+                  description.length === 0 ? newDescription : description
+                }
+              />
               {description.map(description => {
                 return (
                   <MainDescription

--- a/compliance-ui/components/Details.js
+++ b/compliance-ui/components/Details.js
@@ -89,6 +89,10 @@ const details = css`
     `)};
   }
 
+  div[name="control-inner-container"]:focus {
+    outline: none;
+  }
+
   h1[name="history-h1"] {
     font-size: ${theme.font.xl};
     margin-top: ${theme.spacing.xl};
@@ -303,6 +307,7 @@ export const Details = ({ data, err, id }) => {
             />
 
             <Grid2
+              tab="0"
               controlTitle={id}
               titleColour={true}
               releases={sortedData}

--- a/compliance-ui/components/Details.js
+++ b/compliance-ui/components/Details.js
@@ -34,7 +34,9 @@ const detailsWrap = css`
     text-decoration: underline;
     color: ${theme.colour.blackLight};
   }
-
+  li[name="control-box"] {
+    padding: ${theme.spacing.lg} 0;
+  }
   li[name="control-box"]:hover {
     background: white;
   }
@@ -293,6 +295,7 @@ export const Details = ({ data, err, id }) => {
             />
 
             <Grid2
+              controlTitle={id}
               titleColour={true}
               releases={sortedData}
               titleTimestamp={true}
@@ -308,12 +311,5 @@ export const Details = ({ data, err, id }) => {
     </div>
   );
 };
-
-const missing = (
-  <section className={history}>
-    <h1 name="history-h1">History:</h1>
-    <Grid2 tab="0" controls={verificationsData()} />
-  </section>
-);
 
 export default withRouter(Details);

--- a/compliance-ui/components/Details.js
+++ b/compliance-ui/components/Details.js
@@ -119,6 +119,10 @@ const details = css`
       width: 60%;
     }
 
+    p[name="component"] {
+      margin-bottom: 0;
+    }
+
     div p {
       width: 100%;
     }
@@ -137,6 +141,10 @@ const details = css`
     ${mediaQuery.sm(css`
       div p {
         font-size: ${theme.font.xs};
+      }
+
+      p {
+        width: 85%;
       }
     `)};
   }

--- a/compliance-ui/components/Grid.js
+++ b/compliance-ui/components/Grid.js
@@ -204,17 +204,31 @@ export const Grid2 = ({
   titleTimestamp,
   titleColour,
   link = false,
-  tab
+  tab,
+  controlTitle
 }) => {
   return (
     <div>
       {releases.map(item => {
         return (
           <React.Fragment key={item.release}>
-            <a href={`/singlerelease/${item.release}`}>
+            <a
+              aria-label={`Heading: release #: ${
+                item.release
+              }, click to navigate to the release page
+            , or tab to view the ${controlTitle} control history for this release`}
+              href={`/singlerelease/${item.release}`}
+            >
               <h1 name="history-h1">Release #{item.release}</h1>
             </a>
-            <ul name="grid" className={grid} tabIndex="0">
+            <ul
+              name="grid"
+              className={grid}
+              tabIndex="0"
+              aria-label={`${controlTitle} Control list for release #: ${
+                item.release
+              }  `}
+            >
               {item.controls.map(controls => {
                 const controlID = controls.control;
                 return (

--- a/compliance-ui/components/Grid.js
+++ b/compliance-ui/components/Grid.js
@@ -176,7 +176,6 @@ export const Grid = ({ releases: { releases }, link = false, tab }) => {
                         <ControlBox
                           key={index}
                           status={verifications.passed}
-                          tab={tab}
                           id={controlID}
                           references={verifications.references}
                           component={verifications.component}

--- a/compliance-ui/components/Grid.js
+++ b/compliance-ui/components/Grid.js
@@ -9,7 +9,6 @@ const grid = css`
   padding: 0;
   li {
     list-style: none;
-    padding: ${theme.spacing.lg} ${theme.spacing.lg};
     position: static;
     border-top: 1px solid ${theme.colour.grayOutline};
     border-left: 1px solid ${theme.colour.grayOutline};
@@ -61,6 +60,11 @@ const greenBG = css`
   overflow: hidden;
   text-align: left;
   cursor: pointer;
+
+  a {
+    padding: ${theme.spacing.xl};
+  }
+
   p {
     margin: 0 0 ${theme.spacing.md} 0;
     font-size: ${theme.font.md};
@@ -85,6 +89,11 @@ const redBG = css`
   overflow: hidden;
   text-align: left;
   cursor: pointer;
+
+  a {
+    padding: ${theme.spacing.xl};
+  }
+
   p {
     margin: 0 0 ${theme.spacing.md} 0;
     font-size: ${theme.font.md};
@@ -113,7 +122,13 @@ export const Grid = ({ releases: { releases }, link = false, tab }) => {
     <div>
       {releases.map(item => {
         return (
-          <ul key={item.release} name="grid" className={grid} tabIndex="0">
+          <ul
+            aria-label={`Control list for release #: ${item.release}`}
+            key={item.release}
+            name="grid"
+            className={grid}
+            tabIndex="0"
+          >
             {item.controls.map(controls => {
               const controlID = controls.control;
               var stop = false;

--- a/compliance-ui/components/Header.js
+++ b/compliance-ui/components/Header.js
@@ -16,7 +16,8 @@ const bar = css`
   `)};
 
   ${mediaQuery.sm(css`
-    padding: ${theme.spacing.lg} ${theme.spacing.lg} 0 ${theme.spacing.xl};
+    padding: ${theme.spacing.lg} ${theme.spacing.lg} ${theme.spacing.sm}
+      ${theme.spacing.xl};
   `)};
 `;
 

--- a/compliance-ui/components/Layout.js
+++ b/compliance-ui/components/Layout.js
@@ -13,31 +13,9 @@ const layout = css`
 const actions = css`
   width: 100%;
 
-  span {
-    padding-bottom: ${theme.spacing.lg};
-  }
-
-  svg {
-    margin-bottom: ${theme.spacing.lg};
-  }
-
-  ${mediaQuery.lg(css`
-    span {
-      padding-bottom: ${theme.spacing.lg};
-    }
-
-    svg {
-      margin-bottom: ${theme.spacing.lg};
-    }
-  `)};
-
   ${mediaQuery.sm(css`
     div[name="action-bar"] {
       padding-top: 0;
-    }
-    span {
-      padding-bottom: ${theme.spacing.sm};
-      padding-top: ${theme.spacing.sm};
     }
 
     svg {
@@ -47,14 +25,14 @@ const actions = css`
 `;
 
 const actionsBottom = css`
-  background: ${theme.colour.grayLight};
+  padding-top: ${theme.spacing.lg};
+  background: ${theme.colour.blackLight};
   svg {
     fill: ${theme.colour.white};
-    margin-left: ${theme.spacing.sm};
+    margin-right: ${theme.spacing.sm};
   }
 
   span {
-    margin: ${theme.spacing.lg} ${theme.spacing.md} ${theme.spacing.lg} 0;
     color: ${theme.colour.white};
     text-decoration: underline;
   }
@@ -62,11 +40,6 @@ const actionsBottom = css`
   ${mediaQuery.sm(css`
     svg {
       display: none;
-    }
-
-    span {
-      margin: ${theme.spacing.lg} ${theme.spacing.md} ${theme.spacing.md}
-        ${theme.spacing.sm};
     }
   `)}
 `;

--- a/compliance-ui/components/ReleaseBox.js
+++ b/compliance-ui/components/ReleaseBox.js
@@ -4,16 +4,15 @@ import Link from "next/link";
 
 const releaseBoxPassing = css`
   padding: ${theme.spacing.md} ${theme.spacing.lg};
-  border-left: 1px solid ${theme.colour.grayOutline};
-  border-right: 1px solid ${theme.colour.grayOutline};
-  border-top: 1px solid ${theme.colour.grayOutline};
+  border: 1px solid ${theme.colour.grayOutline};
   background: ${theme.colour.white};
+  margin-bottom: ${theme.spacing.sm};
 
   &:hover {
     background: ${theme.colour.greenLight};
   }
 
-  p {
+  time {
     margin: 0;
     font-size: ${theme.font.sm};
     color: ${theme.colour.blackLight};
@@ -72,34 +71,12 @@ ${passingText}
 
 `;
 
-const releaseFocusPassing = css`
-  text-decoration: none;
-
-  div:focus {
-    outline-offset: -4px;
-    outline: 4px solid ${theme.colour.greenDark};
-  }
-`;
-
-const releaseFocusFailing = css`
-  text-decoration: none;
-
-  div:focus {
-    outline-offset: -4px;
-    outline: 4px solid ${theme.colour.redDark};
-  }
-`;
-
 const releaseTitlePassing = css`
   width: 40rem;
 
-  h3[name="releasebox-title"] {
+  h2[name="releasebox-title"] {
     font-size: ${theme.font.lg};
-    margin: 0 0 ${theme.spacing.sm} 0;
-  }
-
-  h3[name="releasebox-title"] span {
-    font-size: ${theme.font.lg};
+    margin: 0 0 0.3rem 0;
     color: ${theme.colour.greenDark};
   }
 
@@ -108,7 +85,7 @@ const releaseTitlePassing = css`
   `)};
 
   ${mediaQuery.sm(css`
-    h3[name="releasebox-title"] {
+    h2[name="releasebox-title"] {
       font-size: ${theme.font.md};
     }
   `)};
@@ -117,7 +94,7 @@ const releaseTitlePassing = css`
 const releaseTitleFailing = css`
   ${releaseTitlePassing}
 
-  h3[name="releasebox-title"] span {
+  h2[name="releasebox-title"] {
     color: ${theme.colour.redDark};
   }
 `;
@@ -137,49 +114,62 @@ const releaseBadges = css`
   `)};
 `;
 
+const passingFocus = css`
+  a:focus {
+    outline: 0;
+
+    div[name="release-box"] {
+      outline-offset: -4px;
+      outline: 4px solid ${theme.colour.greenDark};
+    }
+  }
+`;
+const failingFocus = css`
+  a:focus {
+    outline: 0;
+
+    div[name="release-box"] {
+      outline-offset: -4px;
+      outline: 4px solid ${theme.colour.redDark};
+    }
+  }
+`;
+
 const ReleaseBox = ({ release, timestamp, passed, passing, total, link }) => {
+  const status = passed === "true" ? "Passed" : "Failed";
   return (
-    <li>
-      <Link as={link} href={link}>
-        <a
-          tabIndex="-1"
-          className={
-            passed === "true" ? releaseFocusPassing : releaseFocusFailing
-          }
+    <li
+      tabIndex="-1"
+      className={passed === "true" ? passingFocus : failingFocus}
+    >
+      <a tabIndex="0" name="releasebox-link" href={link}>
+        <div
+          aria-label={`${status} release #: ${release}, ${passing} out of ${total} checks passing, timestamp: ${timestamp}`}
+          name="release-box"
+          className={passed === "true" ? releaseBoxPassing : releaseBoxFailing}
         >
-          <div
-            name="release-box"
-            tabIndex="0"
-            className={
-              passed === "true" ? releaseBoxPassing : releaseBoxFailing
-            }
-          >
-            <div name="inner-container">
-              <div
-                className={
-                  passed === "true" ? releaseTitlePassing : releaseTitleFailing
-                }
+          <div name="inner-container">
+            <div
+              className={
+                passed === "true" ? releaseTitlePassing : releaseTitleFailing
+              }
+            >
+              <h2 name="releasebox-title">
+                {passed === "true" ? "Passed" : "Failed"} release: #{release}
+              </h2>{" "}
+              <time name="releasebox-timestamp">{timestamp}</time>
+            </div>
+            <div name="release-badges" className={releaseBadges}>
+              <span
+                name="releasebox-passing"
+                className={passed === "true" ? passingText : failingText}
               >
-                <h3 name="releasebox-title">
-                  <span>
-                    {passed === "true" ? "Passed" : "Failed"} release: #
-                    {release}
-                  </span>
-                </h3>{" "}
-                <p name="releasebox-timestamp">{timestamp}</p>
-              </div>
-              <div name="release-badges" className={releaseBadges}>
-                <span
-                  name="releasebox-passing"
-                  className={passed === "true" ? passingText : failingText}
-                >
-                  {passing} / {total} checks
-                </span>
-              </div>
+                {passing} / {total} checks
+              </span>
             </div>
           </div>
-        </a>
-      </Link>
+        </div>
+      </a>
     </li>
   );
 };

--- a/compliance-ui/components/controlbox/ControlBox.js
+++ b/compliance-ui/components/controlbox/ControlBox.js
@@ -27,7 +27,7 @@ export const ControlBox = ({
       tabIndex="-1"
       aria-label={`has ${controlStatus}. Description of check: ${description}, ${formattedDate}`}
     >
-      <WithLink tabIndex="0" id={id} link={link}>
+      <WithLink tabIndex="-1" id={id} link={link}>
         <div name="control-inner-container" tabIndex={tab}>
           <Header
             title={title}

--- a/compliance-ui/components/controlbox/ControlBox.js
+++ b/compliance-ui/components/controlbox/ControlBox.js
@@ -18,12 +18,15 @@ export const ControlBox = ({
   tab
 }) => {
   var formattedDate = formatTimestamp(timestamp);
+  var controlStatus = status === "true" ? "passed" : "failed";
   return (
     <li
       tabIndex={tab}
       data-testid="control-box"
       name="control-box"
       className={style}
+      tabIndex="-1"
+      aria-label={`has ${controlStatus}. Description of check: ${description}, ${formattedDate}`}
     >
       <WithLink tabIndex="0" id={id} link={link}>
         <div>

--- a/compliance-ui/components/controlbox/ControlBox.js
+++ b/compliance-ui/components/controlbox/ControlBox.js
@@ -21,7 +21,6 @@ export const ControlBox = ({
   var controlStatus = status === "true" ? "passed" : "failed";
   return (
     <li
-      tabIndex={tab}
       data-testid="control-box"
       name="control-box"
       className={style}
@@ -29,7 +28,7 @@ export const ControlBox = ({
       aria-label={`has ${controlStatus}. Description of check: ${description}, ${formattedDate}`}
     >
       <WithLink tabIndex="0" id={id} link={link}>
-        <div>
+        <div name="control-inner-container" tabIndex={tab}>
           <Header
             title={title}
             status={status}

--- a/compliance-ui/components/controlbox/ControlComponent.js
+++ b/compliance-ui/components/controlbox/ControlComponent.js
@@ -1,7 +1,7 @@
 export const ControlComponent = ({ component }) => {
   if (!component) return null;
   return (
-    <p>
+    <p name="component">
       <strong>Component:</strong> {component}
     </p>
   );

--- a/compliance-ui/components/controlbox/Footer.js
+++ b/compliance-ui/components/controlbox/Footer.js
@@ -22,7 +22,7 @@ const bottomInfo = css`
   ${mediaQuery.sm(css`
     p {
       font-size: ${theme.font.sm};
-      width: 100%;
+      width: 85%;
     }
 
     a {

--- a/compliance-ui/components/controlbox/Footer.js
+++ b/compliance-ui/components/controlbox/Footer.js
@@ -10,6 +10,7 @@ const bottomInfo = css`
     font-size: ${theme.font.md};
     color: ${theme.colour.blackLight};
     margin-bottom: ${theme.spacing.md};
+    margin-left: ${theme.spacing.lg};
     width: 80%;
   }
 

--- a/compliance-ui/components/controlbox/Header.js
+++ b/compliance-ui/components/controlbox/Header.js
@@ -22,21 +22,21 @@ const topInfo = css`
   }
 
   ${mediaQuery.sm(css`
-    display: block;
     margin-bottom: ${theme.spacing.sm};
-
-    span:first-of-type {
-      width: 100%;
+    justify-content: flex-start;
+    h3 {
+      width: auto;
       font-size: ${theme.font.md};
+      margin-bottom: ${theme.spacing.sm};
     }
 
-    span:nth-of-type(2) {
+    span:first-of-type {
       position: relative;
-      bottom: 0.1rem;
       font-size: ${theme.font.xs};
       font-weight: 700;
-      margin-left: ${theme.spacing.sm};
-      padding: 0.18rem 0.45rem;
+      margin-left: ${theme.spacing.lg};
+      margin-bottom: 0;
+      height: 1.1rem;
     }
   `)};
 `;

--- a/compliance-ui/components/controlbox/Header.js
+++ b/compliance-ui/components/controlbox/Header.js
@@ -54,7 +54,8 @@ export const Header = ({
   status,
   timestamp,
   titleTimestamp,
-  titleColour
+  titleColour,
+  formattedDate
 }) => {
   return (
     <div className={topInfo}>

--- a/compliance-ui/components/controlbox/Header.js
+++ b/compliance-ui/components/controlbox/Header.js
@@ -72,11 +72,19 @@ export const Header = ({
         {titleTimestamp ? `${timestamp}` : title}
       </h3>
       {status === "true" ? (
-        <span data-testid="control-box-pass" className={passingText}>
+        <span
+          name="passing-badge"
+          data-testid="control-box-pass"
+          className={passingText}
+        >
           Passed
         </span>
       ) : (
-        <span data-testid="control-box-fail" className={failingText}>
+        <span
+          name="failing-badge"
+          data-testid="control-box-fail"
+          className={failingText}
+        >
           Failed
         </span>
       )}

--- a/compliance-ui/components/controlbox/Header.js
+++ b/compliance-ui/components/controlbox/Header.js
@@ -5,13 +5,16 @@ import { Timestamp } from "./Timestamp";
 const topInfo = css`
   display: flex;
   justify-content: space-between;
-  span:first-of-type {
+  h3 {
     font-size: ${theme.font.lg};
     font-weight: 700;
+    margin-top: 0;
     margin-bottom: ${theme.spacing.md};
+    margin-left: ${theme.spacing.lg};
     width: 80%;
   }
-  span:nth-of-type(2) {
+  span:first-of-type {
+    margin-right: ${theme.spacing.lg};
     font-size: ${theme.font.sm};
     font-weight: 700;
     height: 1.4rem;
@@ -55,7 +58,7 @@ export const Header = ({
 }) => {
   return (
     <div className={topInfo}>
-      <span
+      <h3
         className={
           status === "true" && titleColour === true
             ? passingTitle
@@ -67,7 +70,7 @@ export const Header = ({
         data-testid="control-box-title"
       >
         {titleTimestamp ? `${timestamp}` : title}
-      </span>
+      </h3>
       {status === "true" ? (
         <span data-testid="control-box-pass" className={passingText}>
           Passed

--- a/compliance-ui/components/controlbox/Timestamp.js
+++ b/compliance-ui/components/controlbox/Timestamp.js
@@ -26,6 +26,7 @@ const failingCircle = css`
 const timeStamp = css`
   display: flex;
   align-items: center;
+  margin-left: ${theme.spacing.lg};
 `;
 
 export const Timestamp = ({ status, timestamp }) => {

--- a/compliance-ui/components/controlbox/WithLink.js
+++ b/compliance-ui/components/controlbox/WithLink.js
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export const WithLink = ({ children, id, link }) => {
   const url = `/controls/${id}`;
-  const label = `This link will take you to the ${id} details page`;
+  const label = `Control: ${id}`;
   return link ? (
     <Link as={url} href={`/details?control=${id}`}>
       <a data-testid="control-box-link" aria-label={label}>

--- a/compliance-ui/pages/index.js
+++ b/compliance-ui/pages/index.js
@@ -11,6 +11,7 @@ const releases = css`
   margin: ${theme.spacing.xl} ${theme.spacing.xxl} 0 ${theme.spacing.xxl};
 
   h1 {
+    display: inline-block;
     font-size: ${theme.font.xl};
     color: ${theme.colour.blackLight};
   }
@@ -34,10 +35,8 @@ const releaseList = css`
     list-style: none;
   }
 
-  li:last-of-type {
-    div[name="release-box"] {
-      border-bottom: 1px solid ${theme.colour.grayOutline};
-    }
+  a {
+    text-decoration: none;
   }
 `;
 
@@ -88,7 +87,7 @@ const ReleasesPage = ({ data }) => {
   return (
     <Layout pdf="pdf-releases">
       <div className={releases}>
-        <h1> Latest Releases: </h1>
+        <h1 tabIndex="0"> Latest Releases: </h1>
         <ul className={releaseList}>
           {sortedData.map((singleRelease, index) => {
             var myDate = Number(singleRelease.timestamp);

--- a/compliance-ui/pages/index.js
+++ b/compliance-ui/pages/index.js
@@ -14,6 +14,7 @@ const releases = css`
     display: inline-block;
     font-size: ${theme.font.xl};
     color: ${theme.colour.blackLight};
+    margin: 0;
   }
 
   ${mediaQuery.lg(css`


### PR DESCRIPTION
## This PR consists of the following:

### 1) Fixing some text level semantics:
- Modifying some of the tags to be semantically correct (i.e adding `<time></time>` tag to dates)

### 2) Making sure important elements are selectable by `tabIndex`:
- Due to the some of the html structure resulting from flex-box, there was some weird tab order going on
- Setting certain elements to be omitted from the `tabIndex`
- Using `focus-within` to focus the proper elements in these funny cases

### 3) Making sure important elements have the proper alt-text for screen readers:
- Setting `aria-labels` on these elements in the `tabIndex`
- Making sure this alt-text is descriptive and coherent
- Testing with screen-reader

**Note:** still need to make the list items on `details page` and `singleRelease page` keyboard navigable + back to top button needs to register a click on keystroke