### PR TITLE
Word-break on release headings

### DIFF
--- a/compliance-ui/components/Details.js
+++ b/compliance-ui/components/Details.js
@@ -124,6 +124,8 @@ const details = css`
     font-size: ${theme.font.xl};
     margin-top: ${theme.spacing.xl};
     color: ${theme.colour.blackLight};
+    width: 100%;
+    word-wrap: break-word;
 
     ${mediaQuery.sm(css`
       font-size: ${theme.font.lg};

--- a/compliance-ui/components/ReleaseBox.js
+++ b/compliance-ui/components/ReleaseBox.js
@@ -78,6 +78,7 @@ const releaseTitlePassing = css`
     font-size: ${theme.font.lg};
     margin: 0 0 0.3rem 0;
     color: ${theme.colour.greenDark};
+    word-wrap: break-word;
   }
 
   ${mediaQuery.md(css`


### PR DESCRIPTION
### Updated `word-wrap` property on some headings
- Seeing the heroku deployment made me realise I had not added word break to the headings to deal with such long release titles.
- `word-wrap: break-word` 