### PR TITLE
SiteImprove a11y audit

### DIFF
--- a/compliance-ui/components/ActionBar.js
+++ b/compliance-ui/components/ActionBar.js
@@ -43,7 +43,7 @@ const ActionBar = ({
   keyDownTop
 }) => {
   return (
-    <div role="complementary" name="action-bar" className={actions}>
+    <div name="action-bar" className={actions}>
       {back2top === false ? (
         <PrintButton link={`/${pdf}/${id}`} />
       ) : (

--- a/compliance-ui/components/Details.js
+++ b/compliance-ui/components/Details.js
@@ -124,6 +124,8 @@ const details = css`
     font-size: ${theme.font.xl};
     margin-top: ${theme.spacing.xl};
     color: ${theme.colour.blackLight};
+    width: 100%;
+    word-wrap: break-word;
 
     ${mediaQuery.sm(css`
       font-size: ${theme.font.lg};

--- a/compliance-ui/components/Header.js
+++ b/compliance-ui/components/Header.js
@@ -1,45 +1,31 @@
 import { css } from "emotion";
 import { theme, mediaQuery } from "./styles";
 import { Logo } from "./Logo";
+import { ActionBar } from "../components";
 
 const bar = css`
-  padding: ${theme.spacing.md} ${theme.spacing.xxl} 0 ${theme.spacing.xxl};
-  width: 100%;
   background: ${theme.colour.blackLight};
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  ${mediaQuery.lg(css`
-    padding: ${theme.spacing.md} ${theme.spacing.lg} 0 ${theme.spacing.xl};
-  `)};
-
-  ${mediaQuery.sm(css`
-    padding: ${theme.spacing.lg} ${theme.spacing.lg} ${theme.spacing.sm}
-      ${theme.spacing.xl};
-  `)};
-`;
-
-const h1 = css`
-  font-size: ${theme.font.xl};
-  line-height: 2.8rem;
-  font-weight: 650;
   color: ${theme.colour.white};
-  margin: 0;
 
-  ${mediaQuery.xl(css`
+  h1 {
     font-size: ${theme.font.xl};
-  `)};
+    padding: ${theme.spacing.lg} 0 0 ${theme.spacing.xxl};
+    margin:0;
 
-  ${mediaQuery.lg(css`
-    font-size: 18pt;
-  `)};
+    ${mediaQuery.lg(css`
+      font-size: 18pt;
+      padding: ${theme.spacing.lg} 0 0 ${theme.spacing.xl};
+    `)}
 
-  ${mediaQuery.sm(css`
-    font-size: ${theme.font.lg};
-    line-height: 1.4rem;
-  `)};
+    ${mediaQuery.sm(css`
+      font-size: ${theme.font.lg};
+      padding: ${theme.spacing.lg} 0 ${theme.spacing.xs} ${theme.spacing.xl};
+    `)}
+
+    ${mediaQuery.xs(css`
+      padding: ${theme.spacing.lg} 0 ${theme.spacing.md} ${theme.spacing.xl};
+    `)}
+  }
 `;
 
 const logo = css`
@@ -66,10 +52,29 @@ const logo = css`
   `)};
 `;
 
-const Header = () => (
-  <header name="header" className={bar}>
-    <h1 className={h1}>Are we compliant yet?</h1>
-    <Logo alt="CDS Logo" style={logo} />
+const actions = css`
+  width: 100%;
+
+  ${mediaQuery.sm(css`
+    div[name="action-bar"] {
+      padding-top: 0;
+    }
+
+    svg {
+      display: none;
+    }
+  `)};
+`;
+
+const Header = ({ pdf = "", id = "" }) => (
+  <header name="header">
+    <div className={bar}>
+      <h1>Are we compliant yet?</h1>
+      <Logo alt="CDS Logo" style={logo} />
+      <div className={actions}>
+        <ActionBar pdf={pdf} id={id} />
+      </div>
+    </div>
   </header>
 );
 

--- a/compliance-ui/components/Layout.js
+++ b/compliance-ui/components/Layout.js
@@ -11,20 +11,6 @@ const layout = css`
   flex-direction: column;
 `;
 
-const actions = css`
-  width: 100%;
-
-  ${mediaQuery.sm(css`
-    div[name="action-bar"] {
-      padding-top: 0;
-    }
-
-    svg {
-      display: none;
-    }
-  `)};
-`;
-
 const actionsBottom = css`
   padding-top: ${theme.spacing.lg};
   background: ${theme.colour.blackLight};
@@ -79,15 +65,10 @@ class Layout extends React.Component {
     const { children, pdf = "", id = "" } = this.props;
     return (
       <div className={layout}>
-        <div className={content}>
-          <div>
-            <PageHead />
-            <Header />
-            <div className={actions}>
-              <ActionBar pdf={pdf} id={id} />
-            </div>
-          </div>
-          <div role="main">{children}</div>
+        <PageHead />
+        <Header pdf={pdf} id={id} />
+        <div role="main" className={content}>
+          {children}
         </div>
 
         <div role="contentinfo" className={footer}>

--- a/compliance-ui/components/Logo.js
+++ b/compliance-ui/components/Logo.js
@@ -21,7 +21,7 @@ export const Logo = ({ style }) => {
     <div className={style}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        id="Layer_1"
+        id="Layer_1_Logo"
         viewBox="0 0 144 144"
         className={logoSVG}
       >

--- a/compliance-ui/components/ReleaseBox.js
+++ b/compliance-ui/components/ReleaseBox.js
@@ -78,6 +78,7 @@ const releaseTitlePassing = css`
     font-size: ${theme.font.lg};
     margin: 0 0 0.3rem 0;
     color: ${theme.colour.greenDark};
+    word-wrap: break-word;
   }
 
   ${mediaQuery.md(css`

--- a/compliance-ui/components/icons/PrinterIcon.js
+++ b/compliance-ui/components/icons/PrinterIcon.js
@@ -1,7 +1,7 @@
 export const PrinterIcon = () => {
   return (
     <svg
-      id="Layer_1"
+      id="Layer_1_PrinterIcon"
       data-name="Layer 1"
       name="printer-icon"
       xmlns="http://www.w3.org/2000/svg"

--- a/compliance-ui/components/icons/UpArrowCircle.js
+++ b/compliance-ui/components/icons/UpArrowCircle.js
@@ -1,7 +1,7 @@
 export const UpArrowCircle = () => {
   return (
     <svg
-      id="Layer_1"
+      id="Layer_1_Up"
       data-name="Layer 1"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 496 496"

--- a/compliance-ui/components/styles.js
+++ b/compliance-ui/components/styles.js
@@ -1,11 +1,5 @@
 import { css } from "react-emotion";
 
-/*
-  This function is usually for hover events and such
-  col: is the color in hex
-  amt: is how much you want to darken or lighten, 20 is a good start.
-*/
-
 export const breakpoints = {
   xs: 330,
   sm: 575,
@@ -22,9 +16,9 @@ export const theme = {
     white: "#fff",
     grayOutline: "#b7b7b7",
     grayLight: "#f0efef",
-    redDark: "#CD1D26",
+    redDark: "#AD1D26",
     redLight: "#f8d9dd",
-    greenDark: "#258742",
+    greenDark: "#006600",
     greenLight: "#e0f0e0",
     focusFill: "#F8F7F7",
     focusOutline: "#ADADAD"

--- a/compliance-ui/pages/singleRelease.js
+++ b/compliance-ui/pages/singleRelease.js
@@ -151,27 +151,29 @@ class SingleReleasePage extends React.Component {
     }
 
     return (
-      <Layout pdf={`pdf-singlerelease/${releaseParam}`}>
-        <div data-testid="home" className={singleReleasePage}>
-          <a name="back" href="/" className={back}>
-            <BackIcon fill={theme.colour.blackLight} />
-            <span name="back-text">Back to home</span>
-          </a>
-          <IsReady data={data} />
+      <div>
+        <Layout pdf={`pdf-singlerelease/${releaseParam}`}>
+          <div data-testid="home" className={singleReleasePage}>
+            <a name="back" href="/" className={back}>
+              <BackIcon fill={theme.colour.blackLight} />
+              <span name="back-text">Back to home</span>
+            </a>
+            <IsReady data={data} />
 
-          <GridSingleRelease
-            keyDownSingleRelease={this.keyHandlerSingleRelease}
-            keyDownUL={this.keyHandlerUL}
-            releases={data}
-            link={true}
-            keyDown={this.keyHandler}
-          />
-          <a name="back" href="/" className={back}>
-            <BackIcon fill={theme.colour.blackLight} />
-            <span name="back-text">Back to home</span>
-          </a>
-        </div>
-      </Layout>
+            <GridSingleRelease
+              keyDownSingleRelease={this.keyHandlerSingleRelease}
+              keyDownUL={this.keyHandlerUL}
+              releases={data}
+              link={true}
+              keyDown={this.keyHandler}
+            />
+            <a name="back" href="/" className={back}>
+              <BackIcon fill={theme.colour.blackLight} />
+              <span name="back-text">Back to home</span>
+            </a>
+          </div>
+        </Layout>
+      </div>
     );
   }
 }

--- a/compliance-ui/static/cdsLogo.svg
+++ b/compliance-ui/static/cdsLogo.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Layer_1_cdsLogo" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 144 144" style="enable-background:new 0 0 144 144;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}

--- a/compliance-ui/static/printer.svg
+++ b/compliance-ui/static/printer.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" id="Layer_1_printer" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 122 121.4" style="enable-background:new 0 0 122 121.4;" xml:space="preserve">
 <title>printer</title>
 <path d="M111.8,28.7H10.2C4.6,28.7,0,33.3,0,38.9v47.9h22.2V74.5h77.6v12.3H122V38.9C122,33.3,117.4,28.7,111.8,28.7z M89.2,50.5


### PR DESCRIPTION
## This PR consists of the following:

### Running SiteImprove Chrome Extension to try and find more a11y flaws
1) Landmarks were all messed up, so had to do a bit of restructuring that needed to be done anyway
   - Originally `ActionBar.js` was outside of the header (looking back I think it was because I couldn't get proper alignment with the logo), and that seemed weird so I fixed it and brought everything into the `Header.js` component
    - Removed complementary landmark, it was useless
    - This allowed for the header landmark to be contained outside of the main landmark
    - Updated and tested this with siteImprove and things seem to be in working shape now

2) Color contrast update
    - SiteImprove caught some contrast errors that axe couldn't
    - `redDark` and `greenDark` colors have been updated in the `styles.js` component

3) Word Break
    - Word break was applied to some boxes to handle larger titles after looking at the deployed version with truer data